### PR TITLE
Implement SSL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Usage
 -----
 
 The library provides a ``PrometheusExporterScript`` class that serves as an
-entry point to create services that export Prometheus metrics via an HTTP
+entry point to create services that export Prometheus metrics via an HTTP(s)
 endpoint.
 
 Creating a new exporter is just a matter of subclassing
@@ -79,6 +79,9 @@ Exporter command-line
       -L {CRITICAL,ERROR,WARNING,INFO,DEBUG}, --log-level {CRITICAL,ERROR,WARNING,INFO,DEBUG}
                             minimum level for log messages (default: WARNING)
       --process-stats       include process stats in metrics (default: False)
+      --ssl-private-key     full path to the ssl private key
+      --ssl-public-key      full path to the ssl public key
+      --ssl-ca              full path to the ssl certificate authority (CA)
 
 
 Further options can be added by implementing ``configure_argument_parser()``,
@@ -86,6 +89,10 @@ which receives the ``argparse.ArgumentParser`` instance used by the script.
 
 The ``script`` variable from the example above can be referenced in
 ``pyproject.toml`` to generate the script, like
+
+In order to serve metrics on the HTTPs endpoint both ``ssl-private-key`` and
+``ssl-public-key`` need to be define. The ssl certificate authority
+(i.e. ``ssl-ca``) is optional.
 
 .. code:: toml
 

--- a/prometheus_aioexporter/script.py
+++ b/prometheus_aioexporter/script.py
@@ -40,8 +40,7 @@ class PrometheusExporterScript(Script):  # type: ignore
     registry: MetricsRegistry
 
     def __init__(
-            self, stdout: IO[bytes] | None = None,
-            stderr: IO[bytes] | None = None
+        self, stdout: IO[bytes] | None = None, stderr: IO[bytes] | None = None
     ) -> None:
         super().__init__(stdout=stdout, stderr=stderr)
         self.registry = MetricsRegistry()
@@ -61,7 +60,7 @@ class PrometheusExporterScript(Script):  # type: ignore
         return logging.getLogger(name=self.name)
 
     def configure_argument_parser(
-            self, parser: argparse.ArgumentParser
+        self, parser: argparse.ArgumentParser
     ) -> None:
         """Add configuration to the ArgumentParser.
 
@@ -98,7 +97,7 @@ class PrometheusExporterScript(Script):  # type: ignore
         """
 
     def create_metrics(
-            self, metric_configs: Iterable[MetricConfig]
+        self, metric_configs: Iterable[MetricConfig]
     ) -> dict[str, Metric]:
         """Create and register metrics from a list of MetricConfigs."""
         return self.registry.create_metrics(metric_configs)
@@ -141,17 +140,17 @@ class PrometheusExporterScript(Script):  # type: ignore
         )
         parser.add_argument(
             "--ssl-private-key",
-            type=argparse.FileType('r'),
+            type=argparse.FileType("r"),
             help="full path to the ssl private key",
         )
         parser.add_argument(
             "--ssl-public-key",
-            type=argparse.FileType('r'),
+            type=argparse.FileType("r"),
             help="full path to the ssl public key",
         )
         parser.add_argument(
             "--ssl-ca",
-            type=argparse.FileType('r'),
+            type=argparse.FileType("r"),
             help="full path to the ssl certificate authority (CA)",
         )
         self.configure_argument_parser(parser)

--- a/prometheus_aioexporter/script.py
+++ b/prometheus_aioexporter/script.py
@@ -1,14 +1,13 @@
 """Run a web server providing a Prometheus metrics endpoint."""
 
 import argparse
-from collections.abc import Iterable
 import logging
 import ssl
-from ssl import SSLContext
 import sys
+from collections.abc import Iterable
+from ssl import SSLContext
 from typing import (
     IO,
-    Optional,
 )
 
 from aiohttp.web import Application
@@ -41,7 +40,8 @@ class PrometheusExporterScript(Script):  # type: ignore
     registry: MetricsRegistry
 
     def __init__(
-        self, stdout: IO[bytes] | None = None, stderr: IO[bytes] | None = None
+            self, stdout: IO[bytes] | None = None,
+            stderr: IO[bytes] | None = None
     ) -> None:
         super().__init__(stdout=stdout, stderr=stderr)
         self.registry = MetricsRegistry()
@@ -61,7 +61,7 @@ class PrometheusExporterScript(Script):  # type: ignore
         return logging.getLogger(name=self.name)
 
     def configure_argument_parser(
-        self, parser: argparse.ArgumentParser
+            self, parser: argparse.ArgumentParser
     ) -> None:
         """Add configuration to the ArgumentParser.
 
@@ -98,7 +98,7 @@ class PrometheusExporterScript(Script):  # type: ignore
         """
 
     def create_metrics(
-        self, metric_configs: Iterable[MetricConfig]
+            self, metric_configs: Iterable[MetricConfig]
     ) -> dict[str, Metric]:
         """Create and register metrics from a list of MetricConfigs."""
         return self.registry.create_metrics(metric_configs)
@@ -141,20 +141,17 @@ class PrometheusExporterScript(Script):  # type: ignore
         )
         parser.add_argument(
             "--ssl-private-key",
-            type=str,
-            dest="ssl_private_key",
+            type=argparse.FileType('r'),
             help="full path to the ssl private key",
         )
         parser.add_argument(
             "--ssl-public-key",
-            type=str,
-            dest="ssl_public_key",
+            type=argparse.FileType('r'),
             help="full path to the ssl public key",
         )
         parser.add_argument(
             "--ssl-ca",
-            type=str,
-            dest="ssl_ca",
+            type=argparse.FileType('r'),
             help="full path to the ssl certificate authority (CA)",
         )
         self.configure_argument_parser(parser)
@@ -187,8 +184,7 @@ class PrometheusExporterScript(Script):  # type: ignore
                 ProcessCollector(registry=None)
             )
 
-    @staticmethod
-    def _configure_ssl(args: argparse.Namespace) -> Optional[SSLContext]:
+    def _get_ssl_context(self, args: argparse.Namespace) -> SSLContext | None:
         if args.ssl_private_key is None or args.ssl_public_key is None:
             return None
         cafile = None
@@ -210,7 +206,7 @@ class PrometheusExporterScript(Script):  # type: ignore
             args.port,
             self.registry,
             metrics_path=args.metrics_path,
-            ssl_context=PrometheusExporterScript._configure_ssl(args),
+            ssl_context=self._get_ssl_context(args),
         )
         exporter.app.on_startup.append(self.on_application_startup)
         exporter.app.on_shutdown.append(self.on_application_shutdown)

--- a/prometheus_aioexporter/script.py
+++ b/prometheus_aioexporter/script.py
@@ -188,11 +188,13 @@ class PrometheusExporterScript(Script):  # type: ignore
             return None
         cafile = None
         if args.ssl_ca:
-            cafile = args.ssl_ca
+            cafile = args.ssl_ca.name
         ssl_context = ssl.create_default_context(
             purpose=ssl.Purpose.CLIENT_AUTH, cafile=cafile
         )
-        ssl_context.load_cert_chain(args.ssl_public_key, args.ssl_private_key)
+        ssl_context.load_cert_chain(
+            args.ssl_public_key.name, args.ssl_private_key.name
+        )
 
         return ssl_context
 

--- a/prometheus_aioexporter/script.py
+++ b/prometheus_aioexporter/script.py
@@ -1,14 +1,12 @@
 """Run a web server providing a Prometheus metrics endpoint."""
 
 import argparse
+from collections.abc import Iterable
 import logging
 import ssl
-import sys
-from collections.abc import Iterable
 from ssl import SSLContext
-from typing import (
-    IO,
-)
+import sys
+from typing import IO
 
 from aiohttp.web import Application
 from prometheus_client import (

--- a/prometheus_aioexporter/web.py
+++ b/prometheus_aioexporter/web.py
@@ -7,7 +7,6 @@ from collections.abc import (
 )
 from ssl import SSLContext
 from textwrap import dedent
-from typing import Optional
 
 from aiohttp.web import (
     Application,

--- a/prometheus_aioexporter/web.py
+++ b/prometheus_aioexporter/web.py
@@ -36,7 +36,7 @@ class PrometheusExporter:
     register: MetricsRegistry
     app: Application
     metrics_path: str
-    ssl_context: Optional[SSLContext] = None
+    ssl_context: SSLContext | None = None
 
     _update_handler: UpdateHandler | None = None
 
@@ -48,7 +48,7 @@ class PrometheusExporter:
         port: int,
         registry: MetricsRegistry,
         metrics_path: str = "/metrics",
-        ssl_context: Optional[SSLContext] = None,
+        ssl_context: SSLContext | None = None,
     ) -> None:
         self.name = name
         self.description = description

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ testing = [
   "pytest-aiohttp",
   "pytest-asyncio",
   "pytest-mock",
+  "trustme",
 ]
 [project.urls]
 changelog = "https://github.com/albertodonato/prometheus-aioexporter/blob/main/CHANGES.rst"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+import ssl
+
+import pytest
+import trustme
+
+
+@pytest.fixture
+def ca():
+    return trustme.CA()
+
+
+@pytest.fixture
+def tls_ca_path(ca):
+    with ca.cert_pem.tempfile() as ca_cert_pem:
+        yield ca_cert_pem
+
+
+@pytest.fixture
+def tls_certificate(ca):
+    return ca.issue_cert("localhost", "127.0.0.1", "::1")
+
+
+@pytest.fixture
+def tls_public_key_path(tls_certificate):
+    """Provide a certificate chain PEM file path via fixture."""
+    with tls_certificate.private_key_and_cert_chain_pem.tempfile() as cert_pem:
+        yield cert_pem
+
+
+@pytest.fixture
+def tls_private_key_path(tls_certificate):
+    """Provide a certificate private key PEM file path via fixture."""
+    with tls_certificate.private_key_pem.tempfile() as cert_key_pem:
+        yield cert_key_pem
+
+
+@pytest.fixture
+def ssl_context(tls_certificate):
+    ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    tls_certificate.configure_cert(ssl_ctx)
+    return ssl_ctx
+
+
+@pytest.fixture
+def ssl_context_server(tls_public_key_path, ca):
+    ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+    ca.configure_trust(ssl_ctx)
+    return ssl_ctx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import trustme
 
 @pytest.fixture
 def ca():
-    return trustme.CA()
+    yield trustme.CA()
 
 
 @pytest.fixture
@@ -17,7 +17,7 @@ def tls_ca_path(ca):
 
 @pytest.fixture
 def tls_certificate(ca):
-    return ca.issue_cert("localhost", "127.0.0.1", "::1")
+    yield ca.issue_cert("localhost", "127.0.0.1", "::1")
 
 
 @pytest.fixture
@@ -38,11 +38,11 @@ def tls_private_key_path(tls_certificate):
 def ssl_context(tls_certificate):
     ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     tls_certificate.configure_cert(ssl_ctx)
-    return ssl_ctx
+    yield ssl_ctx
 
 
 @pytest.fixture
 def ssl_context_server(tls_public_key_path, ca):
     ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
     ca.configure_trust(ssl_ctx)
-    return ssl_ctx
+    yield ssl_ctx

--- a/tests/script_test.py
+++ b/tests/script_test.py
@@ -1,6 +1,9 @@
 from io import StringIO
 import logging
+from ssl import SSLContext
 from unittest import mock
+
+import pytest
 
 from prometheus_aioexporter.metric import MetricConfig
 from prometheus_aioexporter.script import PrometheusExporterScript
@@ -13,28 +16,31 @@ class SampleScript(PrometheusExporterScript):
     default_port = 12345
 
 
-class TestPrometheusExporterScript:
-    def test_description(self):
-        """The description attribute returns the class docstring."""
-        assert SampleScript().description == "A sample script"
+@pytest.fixture
+def script():
+    yield SampleScript()
 
-    def test_description_empty(self):
+
+class TestPrometheusExporterScript:
+    def test_description(self, script):
+        """The description attribute returns the class docstring."""
+        assert script.description == "A sample script"
+
+    def test_description_empty(self, script):
         """The description is empty string if no docstring is set."""
-        script = SampleScript()
         script.__doc__ = None
         assert script.description == ""
 
-    def test_logger(self):
+    def test_logger(self, script):
         """The script logger uses the script name."""
-        assert SampleScript().logger.name == "sample-script"
+        assert script.logger.name == "sample-script"
 
-    def test_configure_argument_parser(self):
+    def test_configure_argument_parser(self, script):
         """configure_argument_parser adds specified arguments."""
 
         def configure_argument_parser(parser):
             parser.add_argument("test", help="test argument")
 
-        script = SampleScript()
         script.configure_argument_parser = configure_argument_parser
         parser = script.get_parser()
 
@@ -42,24 +48,24 @@ class TestPrometheusExporterScript:
         parser.print_help(file=fh)
         assert "test argument" in fh.getvalue()
 
-    def test_create_metrics(self):
+    def test_create_metrics(self, script):
         """Metrics are created based on the configuration."""
         configs = [
             MetricConfig("m1", "desc1", "counter", {}),
             MetricConfig("m2", "desc2", "histogram", {}),
         ]
-        metrics = SampleScript().create_metrics(configs)
+        metrics = script.create_metrics(configs)
         assert len(metrics) == 2
         assert metrics["m1"]._type == "counter"
         assert metrics["m2"]._type == "histogram"
 
-    def test_setup_logging(self, mocker):
+    def test_setup_logging(self, mocker, script):
         """Logging is set up."""
         mock_setup_logger = mocker.patch(
             "prometheus_aioexporter.script.setup_logger"
         )
         mocker.patch("prometheus_aioexporter.web.PrometheusExporter.run")
-        SampleScript()([])
+        script([])
         logger_names = (
             "aiohttp.access",
             "aiohttp.internal",
@@ -73,19 +79,68 @@ class TestPrometheusExporterScript:
         ]
         mock_setup_logger.assert_has_calls(calls)
 
-    def test_change_metrics_path(self, mocker):
+    def test_change_metrics_path(self, script):
         """The path under which metrics are exposed can be changed."""
-        script = SampleScript()
         args = script.get_parser().parse_args(
             ["--metrics-path", "/other-path"]
         )
         exporter = script._get_exporter(args)
         assert exporter.metrics_path == "/other-path"
 
-    def test_include_process_stats(self, mocker):
+    def test_only_ssl_key(self, script):
+        """The path under which metrics are exposed can be changed."""
+        args = script.get_parser().parse_args(
+            ["--ssl-private-key", "/my/custom/private.key"]
+        )
+        exporter = script._get_exporter(args)
+        assert exporter.ssl_context is None
+
+    def test_only_ssl_cert(self, script):
+        """The path under which metrics are exposed can be changed."""
+        args = script.get_parser().parse_args(
+            ["--ssl-public-key", "/my/custom/public.pem"]
+        )
+        exporter = script._get_exporter(args)
+        assert exporter.ssl_context is None
+
+    def test_ssl_components_without_ca(
+        self, script, tls_private_key_path, tls_public_key_path
+    ):
+        """The path under which metrics are exposed can be changed."""
+        args = script.get_parser().parse_args(
+            [
+                "--ssl-public-key",
+                tls_public_key_path,
+                "--ssl-private-key",
+                tls_private_key_path,
+            ]
+        )
+        exporter = script._get_exporter(args)
+        assert isinstance(exporter.ssl_context, SSLContext)
+        assert len(exporter.ssl_context.get_ca_certs()) != 1
+
+    def test_ssl_components(
+        self, script, tls_private_key_path, tls_ca_path, tls_public_key_path
+    ):
+        """The path under which metrics are exposed can be changed."""
+        args = script.get_parser().parse_args(
+            [
+                "--ssl-public-key",
+                tls_public_key_path,
+                "--ssl-private-key",
+                tls_private_key_path,
+                "--ssl-ca",
+                tls_ca_path,
+            ]
+        )
+        exporter = script._get_exporter(args)
+        assert isinstance(exporter.ssl_context, SSLContext)
+        assert len(exporter.ssl_context.get_ca_certs()) == 1
+
+    @pytest.mark.xfail
+    def test_include_process_stats(self, mocker, script):
         """The script can include process stats in metrics."""
         mocker.patch("prometheus_aioexporter.web.PrometheusExporter.run")
-        script = SampleScript()
         script(["--process-stats"])
         # process stats are present in the registry
         assert (
@@ -93,22 +148,45 @@ class TestPrometheusExporterScript:
             in script.registry.registry._names_to_collectors
         )
 
-    def test_get_exporter_registers_handlers(self):
+    def test_get_exporter_registers_handlers(self, script):
         """Startup/shutdown handlers are registered with the application."""
-        script = SampleScript()
         args = script.get_parser().parse_args([])
         exporter = script._get_exporter(args)
         assert script.on_application_startup in exporter.app.on_startup
         assert script.on_application_shutdown in exporter.app.on_shutdown
 
-    def test_script_run_exporter(self, mocker):
+    def test_script_run_exporter_ssl(
+        self,
+        mocker,
+        script,
+        ssl_context,
+        tls_private_key_path,
+        tls_public_key_path,
+    ):
         """The script runs the exporter application."""
         mock_run_app = mocker.patch("prometheus_aioexporter.web.run_app")
-        SampleScript()([])
+        script(
+            [
+                "--ssl-public-key",
+                tls_public_key_path,
+                "--ssl-private-key",
+                tls_private_key_path,
+            ]
+        )
+
+        assert isinstance(
+            mock_run_app.call_args.kwargs["ssl_context"], SSLContext
+        )
+
+    def test_script_run_exporter(self, mocker, script):
+        """The script runs the exporter application."""
+        mock_run_app = mocker.patch("prometheus_aioexporter.web.run_app")
+        script([])
         mock_run_app.assert_called_with(
             mock.ANY,
             host=["localhost"],
             port=12345,
             print=mock.ANY,
             access_log_format='%a "%r" %s %b "%{Referrer}i" "%{User-Agent}i"',
+            ssl_context=None,
         )

--- a/tests/script_test.py
+++ b/tests/script_test.py
@@ -104,7 +104,7 @@ class TestPrometheusExporterScript:
         assert exporter.ssl_context is None
 
     def test_ssl_components_without_ca(
-            self, script, tls_private_key_path, tls_public_key_path
+        self, script, tls_private_key_path, tls_public_key_path
     ):
         """The path under which metrics are exposed can be changed."""
         args = script.get_parser().parse_args(
@@ -120,7 +120,7 @@ class TestPrometheusExporterScript:
         assert len(exporter.ssl_context.get_ca_certs()) != 1
 
     def test_ssl_components(
-            self, script, tls_private_key_path, tls_ca_path, tls_public_key_path
+        self, script, tls_private_key_path, tls_ca_path, tls_public_key_path
     ):
         """The path under which metrics are exposed can be changed."""
         args = script.get_parser().parse_args(
@@ -143,8 +143,8 @@ class TestPrometheusExporterScript:
         script(["--process-stats"])
         # process stats are present in the registry
         assert (
-                "process_cpu_seconds_total"
-                in script.registry.registry._names_to_collectors
+            "process_cpu_seconds_total"
+            in script.registry.registry._names_to_collectors
         )
 
     def test_get_exporter_registers_handlers(self, script):
@@ -155,12 +155,12 @@ class TestPrometheusExporterScript:
         assert script.on_application_shutdown in exporter.app.on_shutdown
 
     def test_script_run_exporter_ssl(
-            self,
-            mocker,
-            script,
-            ssl_context,
-            tls_private_key_path,
-            tls_public_key_path,
+        self,
+        mocker,
+        script,
+        ssl_context,
+        tls_private_key_path,
+        tls_public_key_path,
     ):
         """The script runs the exporter application."""
         mock_run_app = mocker.patch("prometheus_aioexporter.web.run_app")

--- a/tests/script_test.py
+++ b/tests/script_test.py
@@ -1,5 +1,5 @@
-import logging
 from io import StringIO
+import logging
 from ssl import SSLContext
 from unittest import mock
 

--- a/tests/script_test.py
+++ b/tests/script_test.py
@@ -1,5 +1,5 @@
-from io import StringIO
 import logging
+from io import StringIO
 from ssl import SSLContext
 from unittest import mock
 
@@ -87,24 +87,24 @@ class TestPrometheusExporterScript:
         exporter = script._get_exporter(args)
         assert exporter.metrics_path == "/other-path"
 
-    def test_only_ssl_key(self, script):
+    def test_only_ssl_key(self, script, tls_private_key_path):
         """The path under which metrics are exposed can be changed."""
         args = script.get_parser().parse_args(
-            ["--ssl-private-key", "/my/custom/private.key"]
+            ["--ssl-private-key", tls_private_key_path]
         )
         exporter = script._get_exporter(args)
         assert exporter.ssl_context is None
 
-    def test_only_ssl_cert(self, script):
+    def test_only_ssl_cert(self, script, tls_public_key_path):
         """The path under which metrics are exposed can be changed."""
         args = script.get_parser().parse_args(
-            ["--ssl-public-key", "/my/custom/public.pem"]
+            ["--ssl-public-key", tls_public_key_path]
         )
         exporter = script._get_exporter(args)
         assert exporter.ssl_context is None
 
     def test_ssl_components_without_ca(
-        self, script, tls_private_key_path, tls_public_key_path
+            self, script, tls_private_key_path, tls_public_key_path
     ):
         """The path under which metrics are exposed can be changed."""
         args = script.get_parser().parse_args(
@@ -120,7 +120,7 @@ class TestPrometheusExporterScript:
         assert len(exporter.ssl_context.get_ca_certs()) != 1
 
     def test_ssl_components(
-        self, script, tls_private_key_path, tls_ca_path, tls_public_key_path
+            self, script, tls_private_key_path, tls_ca_path, tls_public_key_path
     ):
         """The path under which metrics are exposed can be changed."""
         args = script.get_parser().parse_args(
@@ -137,15 +137,14 @@ class TestPrometheusExporterScript:
         assert isinstance(exporter.ssl_context, SSLContext)
         assert len(exporter.ssl_context.get_ca_certs()) == 1
 
-    @pytest.mark.xfail
     def test_include_process_stats(self, mocker, script):
         """The script can include process stats in metrics."""
         mocker.patch("prometheus_aioexporter.web.PrometheusExporter.run")
         script(["--process-stats"])
         # process stats are present in the registry
         assert (
-            "process_cpu_seconds_total"
-            in script.registry.registry._names_to_collectors
+                "process_cpu_seconds_total"
+                in script.registry.registry._names_to_collectors
         )
 
     def test_get_exporter_registers_handlers(self, script):
@@ -156,12 +155,12 @@ class TestPrometheusExporterScript:
         assert script.on_application_shutdown in exporter.app.on_shutdown
 
     def test_script_run_exporter_ssl(
-        self,
-        mocker,
-        script,
-        ssl_context,
-        tls_private_key_path,
-        tls_public_key_path,
+            self,
+            mocker,
+            script,
+            ssl_context,
+            tls_private_key_path,
+            tls_public_key_path,
     ):
         """The script runs the exporter application."""
         mock_run_app = mocker.patch("prometheus_aioexporter.web.run_app")

--- a/tests/web_test.py
+++ b/tests/web_test.py
@@ -73,11 +73,11 @@ class TestPrometheusExporter:
 
     @pytest.mark.parametrize("exporter", [ssl_context, None], indirect=True)
     async def test_homepage(
-            self,
-            ssl_context_server,
-            create_server_client,
-            exporter,
-            aiohttp_client,
+        self,
+        ssl_context_server,
+        create_server_client,
+        exporter,
+        aiohttp_client,
     ):
         """The homepage shows an HTML page."""
         server = await create_server_client(exporter)
@@ -119,7 +119,7 @@ class TestPrometheusExporter:
 
     @pytest.mark.parametrize("ssl_context", [SSLContext(), None])
     async def test_metrics_different_path(
-            self, aiohttp_client, registry, ssl_context
+        self, aiohttp_client, registry, ssl_context
     ):
         """The metrics path can be changed."""
         exporter = PrometheusExporter(
@@ -148,7 +148,7 @@ class TestPrometheusExporter:
 
     @pytest.mark.parametrize("exporter", [ssl_context, None], indirect=True)
     async def test_metrics_update_handler(
-            self, aiohttp_client, exporter, registry
+        self, aiohttp_client, exporter, registry
     ):
         """set_metric_update_handler sets a handler called with metrics."""
         args = []
@@ -171,7 +171,7 @@ class TestPrometheusExporter:
         ["ssl_context", "protocol"], [(ssl_context, "https"), (None, "http")]
     )
     async def test_startup_logger(
-            self, mocker, registry, ssl_context, protocol
+        self, mocker, registry, ssl_context, protocol
     ):
         exporter = PrometheusExporter(
             "test-app",


### PR DESCRIPTION
Introduce backwards compatible SSL.
- [script.py] Add optional argument for ssl-private_key, ssl-public_key and ssl-ca
- [web.py] Add optional ssl_context
- [conftest.py] Pytest utilities to test ssl
- [script_test.py/web_test.py] Add ssl testing