### PR TITLE
Adding CLI parameter to log local variables when using JSON log format

### DIFF
--- a/prometheus_aioexporter/_log.py
+++ b/prometheus_aioexporter/_log.py
@@ -52,6 +52,7 @@ class AccessLogger(AbstractAccessLogger):
 def setup_logging(
     log_format: LogFormat = LogFormat.PLAIN,
     log_level: LogLevel = LogLevel.WARNING,
+    log_locals_json: bool = False,
 ) -> None:
     """Setup logging for the application."""
 
@@ -63,7 +64,7 @@ def setup_logging(
             structlog.processors.add_log_level,
             structlog.processors.ExceptionRenderer(
                 structlog.tracebacks.ExceptionDictTransformer(
-                    show_locals=False
+                    show_locals=log_locals_json
                 )
             ),
             structlog.processors.JSONRenderer(),

--- a/prometheus_aioexporter/_script.py
+++ b/prometheus_aioexporter/_script.py
@@ -216,6 +216,15 @@ class PrometheusExporterScript:
                 show_envvar=True,
             ),
             click.Option(
+                ["--log-locals-json"],
+                help="log local variables when in the JSON output format",
+                type=bool,
+                is_flag=True,
+                default=False,
+                show_default=True,
+                show_envvar=True,
+            ),
+            click.Option(
                 ["--process-stats"],
                 help="include process stats in metrics",
                 type=bool,
@@ -266,7 +275,7 @@ class PrometheusExporterScript:
             sys.exit(1)
 
     def _execute(self, args: Arguments) -> None:
-        setup_logging(args.log_format, args.log_level)
+        setup_logging(args.log_format, args.log_level, args.log_locals_json)
         self.logger.info(
             "startup", version=self.version, python_version=sys.version
         )

--- a/tests/script_test.py
+++ b/tests/script_test.py
@@ -39,6 +39,7 @@ def make_arguments() -> Iterator[Callable[..., Arguments]]:
             "port": 9090,
             "metrics_path": "/metrics",
             "log_level": LogLevel.INFO,
+            "log_locals_json": False,
             "log_format": LogFormat.PLAIN,
             "process_stats": False,
             "ssl_private_key": None,
@@ -203,10 +204,12 @@ class TestPrometheusExporterScript:
             "json",
             "--log-level",
             "debug",
+            "--log-locals-json",
         )
         assert args.process_stats
         assert args.log_format == LogFormat.JSON
         assert args.log_level == LogLevel.DEBUG
+        assert args.log_locals_json == True
 
     def test_arguments_from_cli(
         self,


### PR DESCRIPTION
When this package is consumed from the query-exporter package, by default it logs the local variables in default log format for any exceptions that are encountered. This is quite helpful when troubleshooting certain problems and errors. 

The JSON log format offers more power though especially when logs are being forwarded to an external service. Particularly so that the external service doesn't separate the multi-line plain text log over multiple records. That being said, the JSON format currently doesn't support logging these function local variables as that behavior isn't connected.

This PR adds that functionality in with a new command line parameter. This parameter defaults to off to preserve existing behavior but if supplied, it will tell structlog to include local variables in its log records.